### PR TITLE
Update to embedded_graphics V0.6 and st7735 V0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ gd32vf103xx-hal = "0.3.0"
 embedded-hal = "0.2.3"
 nb = "0.1.2"
 riscv = "0.5.4"
-st7735-lcd = { version = "0.6.1", optional = true }
+st7735-lcd = { version = "0.7", optional = true }
 
 [dev-dependencies]
 riscv-rt = "0.6.1"
 panic-halt = "0.2.0"
-embedded-graphics = "0.5"
+embedded-graphics = "0.6"
 
 [features]
 lcd = ["st7735-lcd"]

--- a/examples/display.rs
+++ b/examples/display.rs
@@ -3,39 +3,53 @@
 
 use panic_halt as _;
 
-use riscv_rt::entry;
+use embedded_graphics::fonts::{Font6x8, Text};
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::Rectangle;
+use embedded_graphics::{primitive_style, text_style};
 use gd32vf103xx_hal::pac;
 use gd32vf103xx_hal::prelude::*;
-use longan_nano::lcd_pins;
-use longan_nano::lcd::Lcd;
-use embedded_graphics::prelude::*;
-use embedded_graphics::fonts::Font6x8;
-use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::primitives::Rectangle;
+use longan_nano::{lcd, lcd_pins};
+use riscv_rt::entry;
 
 #[entry]
 fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
 
     // Configure clocks
-    let mut rcu = dp.RCU.configure().ext_hf_clock(8.mhz()).sysclk(108.mhz()).freeze();
+    let mut rcu = dp
+        .RCU
+        .configure()
+        .ext_hf_clock(8.mhz())
+        .sysclk(108.mhz())
+        .freeze();
     let mut afio = dp.AFIO.constrain(&mut rcu);
 
     let gpioa = dp.GPIOA.split(&mut rcu);
     let gpiob = dp.GPIOB.split(&mut rcu);
 
     let lcd_pins = lcd_pins!(gpioa, gpiob);
-    let mut lcd = Lcd::new(dp.SPI0, lcd_pins, &mut afio, &mut rcu);
-    let (width, height) = (lcd.width() as i32, lcd.height() as i32);
+    let mut lcd = lcd::configure(dp.SPI0, lcd_pins, &mut afio, &mut rcu);
+    let (width, height) = (lcd.size().width as i32, lcd.size().height as i32);
 
     // Clear screen
-    lcd.draw(Rectangle::new(Coord::new(0, 0), Coord::new(width - 1, height - 1))
-        .fill(Some(Rgb565::from(0u16))));
+    Rectangle::new(Point::new(0, 0), Point::new(width - 1, height - 1))
+        .into_styled(primitive_style!(fill_color = Rgb565::BLACK))
+        .draw(&mut lcd)
+        .unwrap();
 
-    let t = Font6x8::render_str(" Hello Rust! ")
-        .fill(Some(Rgb565::from((0,0xff,0))))
-        .translate(Coord::new(40, 35));
-    lcd.draw(t);
+    let style = text_style!(
+        font = Font6x8,
+        text_color = Rgb565::BLACK,
+        background_color = Rgb565::GREEN
+    );
+
+    // Create a text at position (20, 30) and draw it using style defined above
+    Text::new(" Hello Rust! ", Point::new(40, 35))
+        .into_styled(style)
+        .draw(&mut lcd)
+        .unwrap();
 
     loop {}
 }

--- a/examples/ferris.rs
+++ b/examples/ferris.rs
@@ -3,15 +3,16 @@
 
 use panic_halt as _;
 
-use riscv_rt::entry;
-use gd32vf103xx_hal::prelude::*;
-use gd32vf103xx_hal::pac;
-use longan_nano::lcd_pins;
-use longan_nano::lcd::Lcd;
-use embedded_graphics::prelude::*;
+use embedded_graphics::image::{Image, ImageRaw};
+use embedded_graphics::pixelcolor::raw::LittleEndian;
 use embedded_graphics::pixelcolor::Rgb565;
-use embedded_graphics::image::Image16BPP;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitive_style;
 use embedded_graphics::primitives::Rectangle;
+use gd32vf103xx_hal::pac;
+use gd32vf103xx_hal::prelude::*;
+use longan_nano::{lcd, lcd_pins};
+use riscv_rt::entry;
 
 const FERRIS: &[u8] = include_bytes!("ferris.raw");
 
@@ -20,23 +21,32 @@ fn main() -> ! {
     let dp = pac::Peripherals::take().unwrap();
 
     // Configure clocks
-    let mut rcu = dp.RCU.configure().ext_hf_clock(8.mhz()).sysclk(108.mhz()).freeze();
+    let mut rcu = dp
+        .RCU
+        .configure()
+        .ext_hf_clock(8.mhz())
+        .sysclk(108.mhz())
+        .freeze();
     let mut afio = dp.AFIO.constrain(&mut rcu);
 
     let gpioa = dp.GPIOA.split(&mut rcu);
     let gpiob = dp.GPIOB.split(&mut rcu);
 
     let lcd_pins = lcd_pins!(gpioa, gpiob);
-    let mut lcd = Lcd::new(dp.SPI0, lcd_pins, &mut afio, &mut rcu);
-    let (width, height) = (lcd.width() as i32, lcd.height() as i32);
+    let mut lcd = lcd::configure(dp.SPI0, lcd_pins, &mut afio, &mut rcu);
+    let (width, height) = (lcd.size().width as i32, lcd.size().height as i32);
 
     // Clear screen
-    lcd.draw(Rectangle::new(Coord::new(0, 0), Coord::new(width - 1, height - 1))
-        .fill(Some(Rgb565::from(0u16))));
+    Rectangle::new(Point::new(0, 0), Point::new(width - 1, height - 1))
+        .into_styled(primitive_style!(fill_color = Rgb565::BLACK))
+        .draw(&mut lcd)
+        .unwrap();
 
-    let image: Image<Rgb565, _> = Image16BPP::new(&FERRIS, 86, 64);
-    let image = image.translate(Coord::new(width/2 - 43, height/2 - 32));
-    lcd.draw(&image);
+    // Load Image Data
+    let raw_image: ImageRaw<Rgb565, LittleEndian> = ImageRaw::new(&FERRIS, 86, 64);
+    Image::new(&raw_image, Point::new(width / 2 - 43, height / 2 - 32))
+        .draw(&mut lcd)
+        .unwrap();
 
     loop {}
 }

--- a/src/lcd.rs
+++ b/src/lcd.rs
@@ -1,17 +1,16 @@
 //! On-board LCD
 
-use gd32vf103xx_hal::gpio::{Input, Output, Alternate, PushPull, Floating};
+use embedded_hal::digital::v2::OutputPin;
+use gd32vf103xx_hal::afio::Afio;
+use gd32vf103xx_hal::delay::McycleDelay;
 use gd32vf103xx_hal::gpio::gpioa::{PA5, PA6, PA7};
 use gd32vf103xx_hal::gpio::gpiob::{PB0, PB1, PB2};
-use gd32vf103xx_hal::rcu::Rcu;
-use gd32vf103xx_hal::afio::Afio;
-use gd32vf103xx_hal::spi::{Spi, MODE_0};
+use gd32vf103xx_hal::gpio::{Alternate, Floating, Input, Output, PushPull};
 use gd32vf103xx_hal::pac::SPI0;
-use st7735_lcd::{ST7735, Orientation};
-use embedded_hal::digital::v2::OutputPin;
+use gd32vf103xx_hal::rcu::Rcu;
+use gd32vf103xx_hal::spi::{Spi, MODE_0};
 use gd32vf103xx_hal::time::U32Ext;
-use gd32vf103xx_hal::delay::McycleDelay;
-use core::ops::{Deref, DerefMut};
+use st7735_lcd::{Orientation, ST7735};
 
 /// Sets up all the needed GPIO pins for the LCD
 ///
@@ -31,7 +30,7 @@ macro_rules! lcd_pins {
             dc: $gpiob.pb0.into_push_pull_output(),
             rst: $gpiob.pb1.into_push_pull_output(),
         }
-    }}
+    }};
 }
 
 type MisoPin = PA6<Input<Floating>>;
@@ -41,7 +40,7 @@ type CsPin = PB2<Output<PushPull>>;
 type DcPin = PB0<Output<PushPull>>;
 type RstPin = PB1<Output<PushPull>>;
 type SpiType = Spi<SPI0, (SckPin, MisoPin, MosiPin)>;
-type LcdType = ST7735<SpiType, DcPin, RstPin>;
+pub type Lcd = ST7735<SpiType, DcPin, RstPin>;
 
 /// Pins consumed by LCD driver
 pub struct LcdPins {
@@ -53,53 +52,33 @@ pub struct LcdPins {
     pub rst: RstPin,
 }
 
-/// LCD driver wrapper
-pub struct Lcd {
-    driver: LcdType,
-}
+/// Constructs LCD driver from the required components
+pub fn configure(spi: SPI0, pins: LcdPins, afio: &mut Afio, rcu: &mut Rcu) -> Lcd {
+    let (width, height) = (160, 80);
+    let spi0 = Spi::spi0(
+        spi,
+        (pins.sck, pins.miso, pins.mosi),
+        afio,
+        MODE_0,
+        16.mhz(),
+        rcu,
+    );
 
-impl Lcd {
-    /// Constructs LCD driver from the required components
-    pub fn new(spi: SPI0, pins: LcdPins, afio: &mut Afio, rcu: &mut Rcu) -> Lcd {
-        let spi0 = Spi::spi0(spi, (pins.sck, pins.miso, pins.mosi), afio, MODE_0, 16.mhz(), rcu);
+    let mut cs = pins.cs;
+    cs.set_low().unwrap();
 
-        let mut cs = pins.cs;
-        cs.set_low().unwrap();
+    let mut lcd = ST7735::new(
+        spi0, 
+        pins.dc, 
+        pins.rst, 
+        false, 
+        true, 
+        width, 
+        height);
+    let mut delay = McycleDelay::new(&rcu.clocks);
+    lcd.init(&mut delay).unwrap();
+    lcd.set_orientation(&Orientation::Landscape).unwrap();
+    lcd.set_offset(1, 26);
 
-        let mut lcd = ST7735::new(spi0, pins.dc, pins.rst, false, true);
-        let mut delay = McycleDelay::new(&rcu.clocks);
-        lcd.init(&mut delay).unwrap();
-        lcd.set_orientation(&Orientation::Landscape).unwrap();
-        lcd.set_offset(1, 26);
-
-        Lcd {
-            driver: lcd
-        }
+    lcd
     }
-
-    /// Screen width
-    pub const fn width(&self) -> u32 {
-        160
-    }
-
-    /// Screen height
-    pub const fn height(&self) -> u32 {
-        80
-    }
-}
-
-impl Deref for Lcd {
-    type Target = LcdType;
-
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.driver
-    }
-}
-
-impl DerefMut for Lcd {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.driver
-    }
-}


### PR DESCRIPTION
Hi, 

while updateing to the new eg-0.6 API I got a bit confused with the `Deref` implementations on `lcd::Lcd`.  I didn't manage to automatically deref/cast to `DrawTarget<...>`  to make the `embedded_graphics` API work nicely with the `Lcd` type without actually depending/using `embedded_graphics` in this crate.

Long story short: maybe it's ok to just directly return the `ST7735<...>` type without wrapping it in a new `Lcd`? Especially because this does provide a `size()` method now.