### PR TITLE
Add instructions to skip the risc-v toolchain (plus arm64 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ One of:
 - [openocd for GD32VF103](https://github.com/riscv-mcu/riscv-openocd)
 - [RV-LINK](https://gitee.com/zoomdy/RV-LINK)
 
+When using `dfu-util`, the entire RISC-V toolchain is not necessary. Only `objcopy` from [riscv-binutils-gdb](https://github.com/sifive/riscv-binutils-gdb.git) is needed.
+
+It can be compiled with the following commands:
+
+```
+git clone https://github.com/sifive/riscv-binutils-gdb.git
+cd riscv-binutils-gdb
+./configure --target=riscv64-unknown-elf --disable-werror --with-python=no --disable-gdb --disable-sim --disable-libdecnumber --disable-libreadline --with-expat=yes --with-mpc=no --with-mpfr=no --with-gmp=no
+make
+```
+
+It will provide the `binutils/objcopy` tool needed to convert the compiled Rust binary into `firmware.bin` (note: this works on arm64 as well).
+
 ### Building 
 
 If you have a GD32VF103C**B** chip on your board, edit `.cargo/config` and replace
@@ -51,7 +64,6 @@ the correct parameters to flash it sucessfully. As of May 2020, the most recent 
 [dfu-util](http://dfu-util.sourceforge.net/) from the git repository contains a workaround. 
 Make sure you use an up-to-date version.
 See [this issue](https://github.com/riscv-rust/longan-nano/issues/5) for details.
-
 
 Steps to flash an example via DFU:
 


### PR DESCRIPTION
Hi,

I was trying to make this work on **arm64** and realized the `RISC-V toolchain` only provides pre-compiled binaries for `x86_64`. The toolchain also doesn't have a build target for arm64, not to mention that it's a full 6.6GB download and would take 15+ hours to compile. Skipping it would save quite some time and bandwidth.

It turns out only the `objcopy` binary is needed, so I added instructions to build that. It compiled in just a few minutes on a `NanoPi M4V2`, and with `dfu-util` I was able to successfully upload various `firmware.bin` files converted from the compiled Rust examples.

Feel free to modify my instructions as you see fit.

Cheers!