### PR TITLE
Add support for sdcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ embedded-hal = "0.2.3"
 nb = "0.1.2"
 riscv = "0.6.0"
 st7735-lcd = { version = "0.7", optional = true }
+embedded-sdmmc = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 riscv-rt = "0.8.0"
@@ -23,6 +24,7 @@ embedded-graphics = "0.6"
 
 [features]
 lcd = ["st7735-lcd"]
+sdcard = ["embedded-sdmmc"]
 
 [[example]]
 name = "display"
@@ -31,6 +33,10 @@ required-features = ["lcd"]
 [[example]]
 name = "ferris"
 required-features = ["lcd"]
+
+[[example]]
+name = "sdcard_test"
+required-features = ["sdcard"]
 
 [package.metadata.docs.rs]
 features = ['lcd']

--- a/examples/sdcard_test.rs
+++ b/examples/sdcard_test.rs
@@ -1,0 +1,83 @@
+#![no_std]
+#![no_main]
+
+use embedded_sdmmc::{Directory, Volume, VolumeIdx};
+
+use longan_nano::sdcard::SdCard;
+use panic_halt as _;
+
+use riscv_rt::entry;
+use longan_nano::hal::{pac, prelude::*};
+use longan_nano::{sdcard, sprint, sprintln};
+
+#[entry]
+fn main() -> ! {
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Configure clocks
+    let mut rcu = dp.RCU.configure()
+        .ext_hf_clock(8.mhz())
+        .sysclk(108.mhz())
+        .freeze();
+
+    let mut afio = dp.AFIO.constrain(&mut rcu);
+
+    let gpioa = dp.GPIOA.split(&mut rcu);
+    longan_nano::stdout::configure(dp.USART0, gpioa.pa9, gpioa.pa10, 115_200.bps(), &mut afio, &mut rcu);
+
+    let gpiob = dp.GPIOB.split(&mut rcu);
+    let mut sdcard = sdcard::configure(dp.SPI1, gpiob, &mut rcu);
+
+    sprint!("Initializing SD card ... ");
+    if let Err(_) = sdcard.device().init() {
+        sprintln!("Failed to initialize sdcard.");
+    } else {
+        sprintln!("OK");
+        sprint!("SD Card Capacity: ");
+        if let Ok(size) = sdcard.device().card_size_bytes() {
+            sprintln!("{} MB", size / 1000 / 1000);
+            // open the first partition
+            sprintln!("Partition 0:");
+            if let Ok(mut volume) = sdcard.get_volume(VolumeIdx(0)) {
+                // list files in root dir
+                if let Ok(root_dir) = sdcard.open_root_dir(&volume) {
+                    if let Err(_) = sdcard.iterate_dir(&volume, &root_dir, | entry | {
+                        sprintln!("{: >5}B  {}", entry.size, entry.name);
+                    }) {
+                        sprintln!("Error while iterating over files.");
+                    }
+                    if let Ok(_) = sdcard.find_directory_entry(&volume, &root_dir, "W_TST.TXT") {
+                        // if a file with the name W_TST.TXT is present, do a write test
+                        write_test(&mut sdcard, &mut volume, &root_dir);
+                    }
+                } else {
+                    sprintln!("Could not open root directory.");
+                }
+            } else {
+                sprintln!("Could not open partition 0.");
+            }
+        } else {
+            sprintln!("Failed to read card size.");
+        }
+    }
+
+    sprintln!("done.");
+    loop { }
+}
+
+fn write_test(sdcard: &mut SdCard, volume: &mut Volume, dir: &Directory) {
+    sprint!("Write test: ");
+    if let Ok(mut file) = sdcard.open_file_in_dir(volume, dir, "W_TST.CSV", embedded_sdmmc::Mode::ReadWriteCreateOrTruncate) {
+        let data = "1,2,3,4,20";
+        if let Ok(size_written) = sdcard.write(volume, &mut file, data.as_bytes()) {
+            sprintln!("Success (Wrote {}B)", size_written);
+        } else {
+            sprintln!("Failed");
+        }
+        if let Err(_) = sdcard.close_file(volume, file) {
+            sprintln!("Could not close file.");
+        }
+    } else {
+        sprintln!("Could not open file for writing.");
+    }
+}

--- a/examples/sdcard_test.rs
+++ b/examples/sdcard_test.rs
@@ -8,7 +8,7 @@ use panic_halt as _;
 
 use riscv_rt::entry;
 use longan_nano::hal::{pac, prelude::*};
-use longan_nano::{sdcard, sprint, sprintln};
+use longan_nano::{sdcard, sdcard_pins, sprint, sprintln};
 
 #[entry]
 fn main() -> ! {
@@ -26,7 +26,8 @@ fn main() -> ! {
     longan_nano::stdout::configure(dp.USART0, gpioa.pa9, gpioa.pa10, 115_200.bps(), &mut afio, &mut rcu);
 
     let gpiob = dp.GPIOB.split(&mut rcu);
-    let mut sdcard = sdcard::configure(dp.SPI1, gpiob, &mut rcu);
+    let sdcard_pins = sdcard_pins!(gpiob);
+    let mut sdcard = sdcard::configure(dp.SPI1, sdcard_pins, sdcard::SdCardFreq::Safe, &mut rcu);
 
     sprint!("Initializing SD card ... ");
     if let Err(_) = sdcard.device().init() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub use gd32vf103xx_hal as hal;
 pub mod lcd;
 pub mod led;
 pub mod stdout;
+pub mod sdcard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,6 @@ pub use gd32vf103xx_hal as hal;
 pub mod lcd;
 pub mod led;
 pub mod stdout;
+#[cfg(feature = "sdcard")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sdcard")))]
 pub mod sdcard;

--- a/src/sdcard.rs
+++ b/src/sdcard.rs
@@ -1,0 +1,63 @@
+//! On-board SD Card Slot
+
+use embedded_hal::digital::v2::OutputPin;
+use gd32vf103xx_hal::gpio::gpiob::{PB12, PB13, PB14, PB15, Parts};
+use gd32vf103xx_hal::gpio::{Alternate, Floating, Input, Output, PushPull};
+use gd32vf103xx_hal::pac::{SPI1};
+use gd32vf103xx_hal::rcu::Rcu;
+use gd32vf103xx_hal::spi::{Spi, MODE_0};
+use gd32vf103xx_hal::time::U32Ext;
+use embedded_sdmmc::{Controller, SdMmcSpi, TimeSource, Timestamp};
+
+type SckPin = PB13<Alternate<PushPull>>;
+type MisoPin = PB14<Input<Floating>>;
+type MosiPin = PB15<Alternate<PushPull>>;
+type CsPin = PB12<Output<PushPull>>;
+type SPI1Pins = (SckPin, MisoPin, MosiPin);
+
+type Spi1 = Spi<SPI1, SPI1Pins>;
+
+/// A type based on embedded_sdmmc::SdMmcSpi that is used by SdCard.
+pub type SdCardSpi = SdMmcSpi<Spi1, CsPin>;
+
+/// A type based on embedded_sdmmc::Controller.
+pub type SdCard = Controller<SdCardSpi, FakeTimeSource>;
+
+/// Constructs SD Card driver from the required components.
+pub fn configure(spi: SPI1, gpiob: Parts, rcu: &mut Rcu) -> SdCard {
+    let miso = gpiob.pb14.into_floating_input();
+    let mosi = gpiob.pb15.into_alternate_push_pull();
+    let sck = gpiob.pb13.into_alternate_push_pull();
+    let mut cs = gpiob.pb12.into_push_pull_output();
+
+    let spi1 = Spi::spi1(
+        spi,
+        (sck, miso, mosi),
+        MODE_0,
+        300.khz(), // using 300 kHz here because the sdcard init needs 100 to 400 kHz (see SdMmcSpi.init)
+        rcu,
+    );
+
+    cs.set_high().unwrap();
+
+    let sdmmcspi = SdMmcSpi::new(spi1, cs);
+    let ctime_source = FakeTimeSource {};
+
+    Controller::new(sdmmcspi, ctime_source)
+}
+
+/// A fake time source that always returns a date of zero.
+pub struct FakeTimeSource {}
+
+impl TimeSource for FakeTimeSource {
+    fn get_timestamp(&self) -> embedded_sdmmc::Timestamp {
+        Timestamp {
+            year_since_1970: 0,
+            zero_indexed_month: 0,
+            zero_indexed_day: 0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+        }
+    }
+}


### PR DESCRIPTION
Hi,
I made the Sdcard work using [embedded-sdmmc](https://crates.io/crates/embedded-sdmmc). The provided example will print the file names and sizes on the first partition of the Sdcard to the serial terminal. Additionally, if a file named "SDTST.TXT" is present it will write some test data in a file called "SDTST.CSV" and read it back to compare.

The output will look like this:
```
Initializing SD card ... OK
SD Card Capacity: 15577 MB
Partition 0:
    0B  DATA
   34B  TEST.TXT
    0B  TESTDI~1
    0B  READON~1
    0B  SDTST.TXT
Write test: Success (Wrote 10 bytes)
Read test: Success (Read same 10 bytes)
Done
```

Unfortunately it pulls quite a lot of code.

Example      | Size
-----------------|--------------
blinky           | 9504
hello_world  | 8912
display         | 22564
ferris            | 32584
sdcard_test | **70028**

I tested it on a Longan Nano with a GD32VF103CB (128K Flash, 32K RAM). I'm not on an advanced Rust level yet, so please let me know if there are some ways to improve the code (and thus my understanding of Rust).

Possible improvements:
- In is mentioned in SdMmcSpi that the speed of the SPI could be increased after the init, but I couldn't find a way. So right now the SPI operates at 300kHz the whole time.
- Currently the timestamp for write operations is fixed to zero because we don't have a system time and date.

Thanks for this awesome repo,
Gero

Edit: Changed description to match the code after the second commit.