### PR TITLE
Update LCD libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ gd32vf103xx-hal = "0.4.0"
 embedded-hal = "0.2.3"
 nb = "0.1.2"
 riscv = "0.6.0"
-st7735-lcd = { version = "0.7", optional = true }
+st7735-lcd = { version = "0.8", optional = true }
 embedded-sdmmc = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 riscv-rt = "0.8.0"
 panic-halt = "0.2.0"
-embedded-graphics = "0.6"
+embedded-graphics = "0.7"
 ushell = "0.3.3"
 
 [features]
@@ -43,3 +43,4 @@ required-features = ["sdcard"]
 features = ['lcd']
 rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-unknown-linux-gnu"
+

--- a/examples/display.rs
+++ b/examples/display.rs
@@ -3,11 +3,14 @@
 
 use panic_halt as _;
 
-use embedded_graphics::fonts::{Font6x8, Text};
+use embedded_graphics::mono_font::{
+    ascii::FONT_5X8,
+    MonoTextStyleBuilder,
+};
 use embedded_graphics::pixelcolor::Rgb565;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitives::Rectangle;
-use embedded_graphics::{primitive_style, text_style};
+use embedded_graphics::primitives::{Rectangle, PrimitiveStyle};
+use embedded_graphics::text::Text;
 use longan_nano::hal::{pac, prelude::*};
 use longan_nano::{lcd, lcd_pins};
 use riscv_rt::entry;
@@ -33,20 +36,19 @@ fn main() -> ! {
     let (width, height) = (lcd.size().width as i32, lcd.size().height as i32);
 
     // Clear screen
-    Rectangle::new(Point::new(0, 0), Point::new(width - 1, height - 1))
-        .into_styled(primitive_style!(fill_color = Rgb565::BLACK))
+    Rectangle::new(Point::new(0, 0), Size::new(width as u32 - 1, height as u32 - 1))
+        .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
         .draw(&mut lcd)
         .unwrap();
 
-    let style = text_style!(
-        font = Font6x8,
-        text_color = Rgb565::BLACK,
-        background_color = Rgb565::GREEN
-    );
+    let style = MonoTextStyleBuilder::new()
+        .font(&FONT_5X8)
+        .text_color(Rgb565::BLACK)
+        .background_color(Rgb565::GREEN)
+        .build();
 
     // Create a text at position (20, 30) and draw it using style defined above
-    Text::new(" Hello Rust! ", Point::new(40, 35))
-        .into_styled(style)
+    Text::new(" Hello Rust! ", Point::new(40, 35), style)
         .draw(&mut lcd)
         .unwrap();
 

--- a/examples/ferris.rs
+++ b/examples/ferris.rs
@@ -7,8 +7,7 @@ use embedded_graphics::image::{Image, ImageRaw};
 use embedded_graphics::pixelcolor::raw::LittleEndian;
 use embedded_graphics::pixelcolor::Rgb565;
 use embedded_graphics::prelude::*;
-use embedded_graphics::primitive_style;
-use embedded_graphics::primitives::Rectangle;
+use embedded_graphics::primitives::{Rectangle, PrimitiveStyle};
 use longan_nano::hal::{pac, prelude::*};
 use longan_nano::{lcd, lcd_pins};
 use riscv_rt::entry;
@@ -36,13 +35,13 @@ fn main() -> ! {
     let (width, height) = (lcd.size().width as i32, lcd.size().height as i32);
 
     // Clear screen
-    Rectangle::new(Point::new(0, 0), Point::new(width - 1, height - 1))
-        .into_styled(primitive_style!(fill_color = Rgb565::BLACK))
+    Rectangle::new(Point::new(0, 0), Size::new(width as u32 - 1, height as u32 - 1))
+        .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
         .draw(&mut lcd)
         .unwrap();
 
     // Load Image Data
-    let raw_image: ImageRaw<Rgb565, LittleEndian> = ImageRaw::new(&FERRIS, 86, 64);
+    let raw_image: ImageRaw<Rgb565, LittleEndian> = ImageRaw::new(&FERRIS, 86);
     Image::new(&raw_image, Point::new(width / 2 - 43, height / 2 - 32))
         .draw(&mut lcd)
         .unwrap();


### PR DESCRIPTION
Using current `embedded_graphics` in own projects is not possible without updating the LCD driver, so this does it. Docs for older versions are buried, which is a bit annoying too.