### PR TITLE
Use the full screen size to draw the rectangle to clear the screen

### DIFF
--- a/examples/display.rs
+++ b/examples/display.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
     let (width, height) = (lcd.size().width as i32, lcd.size().height as i32);
 
     // Clear screen
-    Rectangle::new(Point::new(0, 0), Size::new(width as u32 - 1, height as u32 - 1))
+    Rectangle::new(Point::new(0, 0), Size::new(width as u32, height as u32))
         .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
         .draw(&mut lcd)
         .unwrap();

--- a/examples/ferris.rs
+++ b/examples/ferris.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
     let (width, height) = (lcd.size().width as i32, lcd.size().height as i32);
 
     // Clear screen
-    Rectangle::new(Point::new(0, 0), Size::new(width as u32 - 1, height as u32 - 1))
+    Rectangle::new(Point::new(0, 0), Size::new(width as u32, height as u32))
         .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
         .draw(&mut lcd)
         .unwrap();


### PR DESCRIPTION
I have just received my Longan Nano and by defaut, the screen is white.
While loading the `ferris` example, I have noticed a white border on the right and the left:

![IMG_20210820_105853](https://user-images.githubusercontent.com/8845664/130210234-2c376cd5-f7da-4537-8565-a62b41dbbc9b.jpg)

And the same with the `display`:

![IMG_20210820_105934](https://user-images.githubusercontent.com/8845664/130210303-42d6d299-6324-45b0-bb12-ac899a3a283b.jpg)

With the proposed fix, the black rectangle has the size of the screen and the white border have now gone:

![IMG_20210820_105543](https://user-images.githubusercontent.com/8845664/130210401-07a3fe63-c5aa-4492-8888-c3df0be678be.jpg)

Might be related to this change in `st7735-lcd`: https://github.com/sajattack/st7735-lcd-rs/pull/12