### PR TITLE
update debugger config

### DIFF
--- a/sipeed-jtag.cfg
+++ b/sipeed-jtag.cfg
@@ -4,11 +4,11 @@
 # https://www.seeedstudio.com/Sipeed-USB-JTAG-TTL-RISC-V-Debugger-p-2910.html
 #
 
-interface ftdi
+adapter driver ftdi
 ftdi_vid_pid 0x0403 0x6010
 ftdi_channel 0
 
 ftdi_layout_init 0x00e8 0x00eb
 
 transport select jtag
-adapter_khz 8000
+adapter speed 8000


### PR DESCRIPTION
update the config so it doesn't show the following deprecated warnings anymore:
- DEPRECATED! use 'adapter driver' not 'interface'
- DEPRECATED! use 'adapter speed' not 'adapter_khz'
